### PR TITLE
Center hero content and simplify styling

### DIFF
--- a/helps.html
+++ b/helps.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Download Translation Helps — translationCore Suite</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body class="helps-page">
+  <header class="site-header helps-header">
+    <div class="brand">
+      <span class="brand-mark">tc</span>
+      <span class="brand-name">translationCore Suite</span>
+    </div>
+    <nav class="site-nav">
+      <a href="index.html#translation-helps">Back to landing</a>
+    </nav>
+  </header>
+
+  <main class="helps-main">
+    <section class="helps-hero">
+      <div class="helps-card">
+        <p class="eyebrow">Translation Notes</p>
+        <h1>Pick a book to open its PDF instantly</h1>
+        <p class="subhead">Choose a Bible book to jump straight into the latest unfoldingWord translation notes (v86.1).</p>
+        <label class="select-label" for="book-select">Book of the Bible</label>
+        <div class="select-wrapper">
+          <select id="book-select" class="book-select">
+            <option value="" disabled selected>Select a book…</option>
+          </select>
+        </div>
+        <p id="download-message" class="hero-status helps-status" aria-live="polite"></p>
+      </div>
+    </section>
+  </main>
+
+  <script src="scripts/helps.js" defer></script>
+</body>
+</html>

--- a/images/church-training-preview.svg
+++ b/images/church-training-preview.svg
@@ -1,0 +1,27 @@
+<svg width="640" height="420" viewBox="0 0 640 420" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="training-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fde68a" />
+      <stop offset="100%" stop-color="#f59e0b" />
+    </linearGradient>
+    <linearGradient id="training-card" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#fff7ed" />
+      <stop offset="100%" stop-color="#fed7aa" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="420" rx="36" fill="url(#training-bg)" />
+  <g filter="url(#trainingShadow)">
+    <path d="M120 150C120 132.327 134.327 118 152 118H488C505.673 118 520 132.327 520 150V294C520 311.673 505.673 326 488 326H152C134.327 326 120 311.673 120 294V150Z" fill="url(#training-card)" />
+    <path d="M184 214C184 185.938 206.938 163 235 163C263.062 163 286 185.938 286 214V260H184V214Z" fill="#f59e0b" fill-opacity="0.35" />
+    <path d="M354 210C354 193.431 367.431 180 384 180H452C468.569 180 482 193.431 482 210V260H354V210Z" fill="#92400e" fill-opacity="0.2" />
+    <rect x="184" y="272" width="298" height="28" rx="14" fill="#7c2d12" fill-opacity="0.15" />
+    <rect x="184" y="308" width="240" height="16" rx="8" fill="#7c2d12" fill-opacity="0.18" />
+    <rect x="184" y="134" width="240" height="12" rx="6" fill="#7c2d12" fill-opacity="0.3" />
+  </g>
+  <defs>
+    <filter id="trainingShadow" x="100" y="106" width="440" height="240" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix" />
+      <feDropShadow dx="0" dy="18" stdDeviation="22" flood-color="#b45309" flood-opacity="0.35" />
+    </filter>
+  </defs>
+</svg>

--- a/images/foundations-preview.svg
+++ b/images/foundations-preview.svg
@@ -1,0 +1,29 @@
+<svg width="640" height="420" viewBox="0 0 640 420" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="foundations-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#334155" />
+      <stop offset="100%" stop-color="#0f172a" />
+    </linearGradient>
+    <linearGradient id="foundations-card" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#e2e8f0" />
+      <stop offset="100%" stop-color="#cbd5f5" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="420" rx="36" fill="url(#foundations-bg)" />
+  <g filter="url(#foundationsShadow)">
+    <rect x="88" y="92" width="464" height="288" rx="32" fill="url(#foundations-card)" />
+    <rect x="132" y="132" width="170" height="26" rx="13" fill="#0f172a" fill-opacity="0.3" />
+    <rect x="132" y="170" width="300" height="18" rx="9" fill="#0f172a" fill-opacity="0.18" />
+    <rect x="132" y="198" width="276" height="18" rx="9" fill="#0f172a" fill-opacity="0.12" />
+    <rect x="132" y="226" width="240" height="18" rx="9" fill="#0f172a" fill-opacity="0.08" />
+    <rect x="132" y="270" width="360" height="72" rx="24" fill="#0f172a" fill-opacity="0.12" />
+    <path d="M168 294C168 278.536 180.536 266 196 266H340C355.464 266 368 278.536 368 294V324H168V294Z" fill="#1e293b" fill-opacity="0.3" />
+    <rect x="196" y="306" width="200" height="18" rx="9" fill="#0f172a" fill-opacity="0.25" />
+  </g>
+  <defs>
+    <filter id="foundationsShadow" x="68" y="80" width="504" height="328" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix" />
+      <feDropShadow dx="0" dy="20" stdDeviation="24" flood-color="#0f172a" flood-opacity="0.45" />
+    </filter>
+  </defs>
+</svg>

--- a/images/translation-helps-preview.svg
+++ b/images/translation-helps-preview.svg
@@ -1,0 +1,30 @@
+<svg width="640" height="420" viewBox="0 0 640 420" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="helps-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#fbbf24" />
+      <stop offset="100%" stop-color="#f97316" />
+    </linearGradient>
+    <linearGradient id="card" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffffff" />
+      <stop offset="100%" stop-color="#fef3c7" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="420" rx="36" fill="url(#helps-bg)" />
+  <g filter="url(#helpsShadow)">
+    <rect x="80" y="82" width="480" height="280" rx="28" fill="url(#card)" />
+    <rect x="120" y="122" width="160" height="28" rx="14" fill="#fbbf24" fill-opacity="0.7" />
+    <rect x="120" y="166" width="400" height="18" rx="9" fill="#1f2937" fill-opacity="0.2" />
+    <rect x="120" y="196" width="360" height="18" rx="9" fill="#1f2937" fill-opacity="0.14" />
+    <rect x="120" y="226" width="260" height="18" rx="9" fill="#1f2937" fill-opacity="0.1" />
+    <rect x="120" y="268" width="360" height="60" rx="16" fill="#fef3c7" stroke="#f59e0b" stroke-width="2" />
+    <circle cx="156" cy="298" r="18" fill="#f59e0b" fill-opacity="0.5" />
+    <rect x="190" y="286" width="220" height="24" rx="12" fill="#1f2937" fill-opacity="0.2" />
+    <rect x="190" y="316" width="180" height="14" rx="7" fill="#1f2937" fill-opacity="0.16" />
+  </g>
+  <defs>
+    <filter id="helpsShadow" x="60" y="70" width="520" height="320" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix" />
+      <feDropShadow dx="0" dy="18" stdDeviation="22" flood-color="#f97316" flood-opacity="0.3" />
+    </filter>
+  </defs>
+</svg>

--- a/images/translationcore-preview.svg
+++ b/images/translationcore-preview.svg
@@ -1,0 +1,32 @@
+<svg width="640" height="420" viewBox="0 0 640 420" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <defs>
+    <linearGradient id="tc-bg" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0%" stop-color="#0a84ff" />
+      <stop offset="100%" stop-color="#1d1d1f" />
+    </linearGradient>
+    <linearGradient id="tc-pane" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.95" />
+      <stop offset="100%" stop-color="#f5f5f7" />
+    </linearGradient>
+  </defs>
+  <rect width="640" height="420" rx="36" fill="url(#tc-bg)" />
+  <g filter="url(#shadow)">
+    <rect x="54" y="54" width="532" height="312" rx="24" fill="url(#tc-pane)" />
+    <rect x="54" y="54" width="532" height="72" rx="24" fill="#111827" />
+    <circle cx="94" cy="90" r="10" fill="#f87171" />
+    <circle cx="128" cy="90" r="10" fill="#facc15" />
+    <circle cx="162" cy="90" r="10" fill="#34d399" />
+    <rect x="108" y="160" width="164" height="160" rx="18" fill="#2563eb" fill-opacity="0.12" />
+    <rect x="300" y="160" width="220" height="32" rx="16" fill="#0f172a" fill-opacity="0.1" />
+    <rect x="300" y="206" width="220" height="32" rx="16" fill="#0f172a" fill-opacity="0.08" />
+    <rect x="300" y="252" width="180" height="32" rx="16" fill="#0f172a" fill-opacity="0.06" />
+    <rect x="300" y="298" width="132" height="24" rx="12" fill="#0f172a" fill-opacity="0.15" />
+    <rect x="108" y="332" width="164" height="12" rx="6" fill="#2563eb" fill-opacity="0.2" />
+  </g>
+  <defs>
+    <filter id="shadow" x="34" y="42" width="572" height="352" filterUnits="userSpaceOnUse" color-interpolation-filters="sRGB">
+      <feFlood flood-opacity="0" result="BackgroundImageFix" />
+      <feDropShadow dx="0" dy="24" stdDeviation="24" flood-color="#0f172a" flood-opacity="0.25" />
+    </filter>
+  </defs>
+</svg>

--- a/index.html
+++ b/index.html
@@ -1,0 +1,82 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>translationCore — unfoldingWord Resources</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body>
+  <header class="site-header">
+    <div class="brand">
+      <span class="brand-mark">tc</span>
+      <span class="brand-name">translationCore Suite</span>
+    </div>
+    <nav class="site-nav">
+      <a href="#translationcore">translationCore</a>
+      <a href="#translation-helps">Helps</a>
+      <a href="#church-training">Church-Based Training</a>
+      <a href="#foundations-bt">Foundations BT</a>
+    </nav>
+  </header>
+
+  <main>
+    <section id="translationcore" class="hero hero-translationcore" style="--hero-image: url('https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=2400&q=80');">
+      <div class="hero-content">
+        <div class="hero-copy">
+          <p class="eyebrow">translationCore software</p>
+          <h1>translationCore</h1>
+          <p class="subhead">A focused desktop workspace that keeps translation teams aligned with checks, notes, and alignment tools built for church-led movements.</p>
+          <div class="hero-actions">
+            <button id="download-translationcore" class="cta primary">Download</button>
+            <a class="cta secondary" href="https://translationcore.com" target="_blank" rel="noopener">Learn more</a>
+          </div>
+          <p class="hero-status" id="download-status" aria-live="polite"></p>
+        </div>
+      </div>
+    </section>
+
+    <section id="translation-helps" class="hero hero-helps" style="--hero-image: url('https://images.unsplash.com/photo-1524995997946-a1c2e315a42f?auto=format&fit=crop&w=2400&q=80');">
+      <div class="hero-content">
+        <div class="hero-copy">
+          <p class="eyebrow">unfoldingWord translation helps</p>
+          <h2>Insights and notes that illuminate every verse</h2>
+          <p class="subhead">Download the latest translation notes, questions, and key terms so your team never loses momentum in Scripture checking.</p>
+          <div class="hero-actions">
+            <a class="cta primary" href="helps.html">Download helps</a>
+            <a class="cta secondary" href="https://preview.door43.org" target="_blank" rel="noopener">Choose your own</a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="church-training" class="hero hero-training" style="--hero-image: url('https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=2400&q=80');">
+      <div class="hero-content">
+        <div class="hero-copy">
+          <p class="eyebrow">Church-Based Training</p>
+          <h2>Equip everyday believers to plant and grow churches</h2>
+          <p class="subhead">ChurchBased Training delivers immersive tracks that help leaders disciple, multiply, and steward God’s Word in their communities.</p>
+          <div class="hero-actions">
+            <a class="cta primary" href="https://churchbased.bible/training/" target="_blank" rel="noopener">Learn more</a>
+          </div>
+        </div>
+      </div>
+    </section>
+
+    <section id="foundations-bt" class="hero hero-foundations" style="--hero-image: url('https://images.unsplash.com/photo-1471286174890-9c112ffca5b4?auto=format&fit=crop&w=2400&q=80');">
+      <div class="hero-content">
+        <div class="hero-copy">
+          <p class="eyebrow">Foundations Bible Translation</p>
+          <h2>Form gospel-centered translators with guided cohorts</h2>
+          <p class="subhead">Foundations BT walks emerging teams through practical labs and coaching so new translation movements launch with confidence.</p>
+          <div class="hero-actions">
+            <a class="cta primary" href="https://foundationsbt.com/" target="_blank" rel="noopener">Foundations of BT</a>
+          </div>
+        </div>
+      </div>
+    </section>
+  </main>
+
+  <script src="scripts/main.js" defer></script>
+</body>
+</html>

--- a/scripts/helps.js
+++ b/scripts/helps.js
@@ -1,0 +1,155 @@
+const TRANSLATION_NOTES_BASE = 'https://preview.door43.org/u/unfoldingWord/en_tn/v86.1';
+
+const BOOK_GROUPS = [
+  {
+    label: 'Pentateuch',
+    books: [
+      ['Genesis', 'gen'],
+      ['Exodus', 'exo'],
+      ['Leviticus', 'lev'],
+      ['Numbers', 'num'],
+      ['Deuteronomy', 'deu']
+    ]
+  },
+  {
+    label: 'Historical Books',
+    books: [
+      ['Joshua', 'jos'],
+      ['Judges', 'jdg'],
+      ['Ruth', 'rut'],
+      ['1 Samuel', '1sa'],
+      ['2 Samuel', '2sa'],
+      ['1 Kings', '1ki'],
+      ['2 Kings', '2ki'],
+      ['1 Chronicles', '1ch'],
+      ['2 Chronicles', '2ch'],
+      ['Ezra', 'ezr'],
+      ['Nehemiah', 'neh'],
+      ['Esther', 'est']
+    ]
+  },
+  {
+    label: 'Wisdom Literature',
+    books: [
+      ['Job', 'job'],
+      ['Psalms', 'psa'],
+      ['Proverbs', 'pro'],
+      ['Ecclesiastes', 'ecc'],
+      ['Song of Songs', 'sng']
+    ]
+  },
+  {
+    label: 'Major Prophets',
+    books: [
+      ['Isaiah', 'isa'],
+      ['Jeremiah', 'jer'],
+      ['Lamentations', 'lam'],
+      ['Ezekiel', 'ezk'],
+      ['Daniel', 'dan']
+    ]
+  },
+  {
+    label: 'Minor Prophets',
+    books: [
+      ['Hosea', 'hos'],
+      ['Joel', 'jol'],
+      ['Amos', 'amo'],
+      ['Obadiah', 'oba'],
+      ['Jonah', 'jon'],
+      ['Micah', 'mic'],
+      ['Nahum', 'nam'],
+      ['Habakkuk', 'hab'],
+      ['Zephaniah', 'zep'],
+      ['Haggai', 'hag'],
+      ['Zechariah', 'zec'],
+      ['Malachi', 'mal']
+    ]
+  },
+  {
+    label: 'Gospels & Acts',
+    books: [
+      ['Matthew', 'mat'],
+      ['Mark', 'mrk'],
+      ['Luke', 'luk'],
+      ['John', 'jhn'],
+      ['Acts', 'act']
+    ]
+  },
+  {
+    label: 'Pauline Epistles',
+    books: [
+      ['Romans', 'rom'],
+      ['1 Corinthians', '1co'],
+      ['2 Corinthians', '2co'],
+      ['Galatians', 'gal'],
+      ['Ephesians', 'eph'],
+      ['Philippians', 'php'],
+      ['Colossians', 'col'],
+      ['1 Thessalonians', '1th'],
+      ['2 Thessalonians', '2th'],
+      ['1 Timothy', '1ti'],
+      ['2 Timothy', '2ti'],
+      ['Titus', 'tit'],
+      ['Philemon', 'phm']
+    ]
+  },
+  {
+    label: 'General Epistles & Revelation',
+    books: [
+      ['Hebrews', 'heb'],
+      ['James', 'jas'],
+      ['1 Peter', '1pe'],
+      ['2 Peter', '2pe'],
+      ['1 John', '1jn'],
+      ['2 John', '2jn'],
+      ['3 John', '3jn'],
+      ['Jude', 'jud'],
+      ['Revelation', 'rev']
+    ]
+  }
+];
+
+function populateBookSelect(select) {
+  BOOK_GROUPS.forEach((group) => {
+    const optgroup = document.createElement('optgroup');
+    optgroup.label = group.label;
+    group.books.forEach(([label, code]) => {
+      const option = document.createElement('option');
+      option.value = code;
+      option.textContent = label;
+      option.dataset.label = label;
+      optgroup.append(option);
+    });
+    select.append(optgroup);
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const select = document.getElementById('book-select');
+  const message = document.getElementById('download-message');
+
+  if (!select) return;
+
+  populateBookSelect(select);
+
+  select.addEventListener('change', (event) => {
+    const { value, selectedOptions } = event.target;
+    if (!value) {
+      return;
+    }
+
+    const selectedLabel = selectedOptions && selectedOptions[0]
+      ? selectedOptions[0].dataset.label || selectedOptions[0].textContent
+      : 'the selected book';
+
+    if (message) {
+      message.textContent = `Preparing translation notes for ${selectedLabel}…`;
+    }
+
+    const downloadUrl = `${TRANSLATION_NOTES_BASE}?book=${encodeURIComponent(value)}`;
+
+    setTimeout(() => {
+      window.location.href = downloadUrl;
+    }, 600);
+  });
+});

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -1,0 +1,136 @@
+const RELEASE_API = 'https://api.github.com/repos/unfoldingWord/translationCore/releases/latest';
+const RELEASE_FALLBACK = 'https://github.com/unfoldingWord/translationCore/releases/latest';
+
+function detectOperatingSystem() {
+  const { userAgent, platform } = window.navigator;
+  const normalizedUA = userAgent.toLowerCase();
+  const normalizedPlatform = (platform || '').toLowerCase();
+
+  if (/(windows|win32|win64)/i.test(normalizedUA + normalizedPlatform)) {
+    return 'windows';
+  }
+
+  if (/(macintosh|macintel|mac os|mac_powerpc|darwin)/i.test(normalizedUA + normalizedPlatform)) {
+    return 'mac';
+  }
+
+  if (/(linux|x11|ubuntu|debian|fedora)/i.test(normalizedUA + normalizedPlatform)) {
+    return 'linux';
+  }
+
+  return 'unknown';
+}
+
+function rankAssetForOS(assetName, os) {
+  const name = assetName.toLowerCase();
+
+  const preferences = {
+    windows: [/\.exe$/, /windows/, /win64/, /win32/, /\.msi$/],
+    mac: [/\.dmg$/, /mac/, /osx/, /darwin/],
+    linux: [/\.appimage$/, /linux/, /\.deb$/, /\.tar\.gz$/]
+  };
+
+  const patterns = preferences[os] || [];
+
+  for (let i = 0; i < patterns.length; i += 1) {
+    if (patterns[i].test(name)) {
+      return patterns.length - i;
+    }
+  }
+
+  return 0;
+}
+
+function chooseBestAsset(assets, os) {
+  if (!Array.isArray(assets) || assets.length === 0) {
+    return null;
+  }
+
+  if (os === 'unknown') {
+    return assets[0];
+  }
+
+  let best = null;
+  let highestScore = 0;
+
+  assets.forEach((asset) => {
+    if (!asset || !asset.name) return;
+    const score = rankAssetForOS(asset.name, os);
+    if (score > highestScore) {
+      highestScore = score;
+      best = asset;
+    }
+  });
+
+  return best || assets[0];
+}
+
+async function fetchLatestAsset() {
+  const response = await fetch(RELEASE_API, {
+    headers: {
+      'Accept': 'application/vnd.github+json',
+      'X-GitHub-Api-Version': '2022-11-28'
+    }
+  });
+
+  if (!response.ok) {
+    throw new Error(`GitHub API request failed: ${response.status}`);
+  }
+
+  const data = await response.json();
+  const os = detectOperatingSystem();
+  const asset = chooseBestAsset(data.assets || [], os);
+
+  return { asset, os };
+}
+
+function resetButton(button, originalText) {
+  if (!button) return;
+  button.disabled = false;
+  button.textContent = originalText;
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  const downloadButton = document.getElementById('download-translationcore');
+  const statusEl = document.getElementById('download-status');
+
+  if (!downloadButton) return;
+
+  const originalText = downloadButton.textContent;
+
+  downloadButton.addEventListener('click', async () => {
+    downloadButton.disabled = true;
+    downloadButton.textContent = 'Preparing download…';
+    if (statusEl) {
+      statusEl.textContent = 'Looking for the latest translationCore release for your device…';
+    }
+
+    try {
+      const { asset, os } = await fetchLatestAsset();
+
+      if (!asset || !asset.browser_download_url) {
+        throw new Error('No download available for your platform.');
+      }
+
+      if (statusEl) {
+        const osLabel = os === 'unknown' ? 'your device' : os.toUpperCase();
+        statusEl.textContent = `Starting ${osLabel} download…`;
+      }
+
+      window.location.href = asset.browser_download_url;
+    } catch (error) {
+      console.error(error);
+      if (statusEl) {
+        statusEl.textContent = 'Unable to find an automatic download. Redirecting you to the releases page…';
+      }
+      window.open(RELEASE_FALLBACK, '_blank', 'noopener');
+    } finally {
+      setTimeout(() => {
+        if (statusEl) {
+          statusEl.textContent = '';
+        }
+        resetButton(downloadButton, originalText);
+      }, 2500);
+    }
+  });
+});

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,335 @@
+:root {
+  color-scheme: light;
+  --text-primary: #1d1d1f;
+  --text-secondary: #515154;
+  --surface: #f5f5f7;
+  --surface-dark: #000000;
+  --surface-light: #ffffff;
+  --accent: #0071e3;
+  --accent-dark: #005bb5;
+  --cta-secondary: #1d1d1f;
+  font-family: "SF Pro Display", "SF Pro Text", -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background-color: var(--surface);
+  color: var(--text-primary);
+  font-family: inherit;
+  -webkit-font-smoothing: antialiased;
+}
+
+a {
+  color: inherit;
+}
+
+img {
+  max-width: 100%;
+  display: block;
+  height: auto;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 20px clamp(24px, 4vw, 64px);
+  background-color: rgba(255, 255, 255, 0.8);
+  backdrop-filter: saturate(180%) blur(16px);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.site-header.helps-header {
+  position: static;
+}
+
+.brand {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.brand-mark {
+  display: inline-flex;
+  width: 40px;
+  height: 40px;
+  border-radius: 12px;
+  background: linear-gradient(135deg, #0a84ff, #1d1d1f);
+  color: #fff;
+  font-size: 1.2rem;
+  align-items: center;
+  justify-content: center;
+  text-transform: uppercase;
+}
+
+.brand-name {
+  font-size: 1rem;
+  color: var(--text-primary);
+}
+
+.site-nav {
+  display: flex;
+  gap: clamp(16px, 4vw, 36px);
+  font-size: 0.95rem;
+  font-weight: 500;
+}
+
+.site-nav a {
+  text-decoration: none;
+  position: relative;
+  padding-bottom: 4px;
+}
+
+.site-nav a::after {
+  content: "";
+  position: absolute;
+  left: 0;
+  bottom: 0;
+  width: 100%;
+  height: 1px;
+  background-color: currentColor;
+  transform: scaleX(0);
+  transform-origin: right;
+  transition: transform 200ms ease;
+}
+
+.site-nav a:focus-visible,
+.site-nav a:hover {
+  color: var(--accent);
+}
+
+.site-nav a:hover::after,
+.site-nav a:focus-visible::after {
+  transform: scaleX(1);
+  transform-origin: left;
+}
+
+main {
+  display: block;
+  padding-bottom: clamp(80px, 12vw, 160px);
+}
+
+.hero {
+  position: relative;
+  isolation: isolate;
+  min-height: clamp(520px, 78vh, 760px);
+  padding: clamp(96px, 16vw, 160px) clamp(24px, 6vw, 96px);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: #fff;
+  background-color: #000;
+  background-image: linear-gradient(180deg, rgba(0, 0, 0, 0.65) 0%, rgba(0, 0, 0, 0.45) 40%, rgba(0, 0, 0, 0.65) 100%), var(--hero-image);
+  background-size: cover;
+  background-position: center;
+}
+
+.hero-content {
+  width: min(100%, 780px);
+  margin: 0 auto;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(24px, 6vw, 48px);
+}
+
+.hero-copy {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(16px, 4vw, 24px);
+}
+
+.hero h1,
+.hero h2 {
+  margin: 0;
+  font-weight: 600;
+  letter-spacing: -0.02em;
+}
+
+.hero h1 {
+  font-size: clamp(2.4rem, 6vw, 3.6rem);
+}
+
+.hero h2 {
+  font-size: clamp(2rem, 5vw, 3rem);
+}
+
+.eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.24em;
+  font-size: 0.8rem;
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+}
+
+.hero .eyebrow {
+  color: rgba(255, 255, 255, 0.68);
+}
+
+.subhead {
+  color: var(--text-secondary);
+  font-size: clamp(1rem, 2.6vw, 1.2rem);
+  line-height: 1.6;
+  margin: 0 auto clamp(24px, 5vw, 36px);
+  max-width: 520px;
+}
+
+.hero .subhead {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+.hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: center;
+  gap: clamp(16px, 4vw, 28px);
+}
+
+.cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 6px;
+  font-size: 1.05rem;
+  font-weight: 600;
+  text-decoration: none;
+  cursor: pointer;
+  padding: 14px 34px;
+  border-radius: 999px;
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  background: rgba(255, 255, 255, 0.12);
+  color: #fff;
+  transition: transform 200ms ease, box-shadow 200ms ease, background-color 200ms ease, color 200ms ease;
+}
+
+.cta.primary {
+  background: #ffffff;
+  color: #111111;
+  border-color: #ffffff;
+}
+
+.cta::after {
+  content: "›";
+  font-size: 1.15em;
+  transform: translateY(-1px);
+}
+
+.cta.primary:hover,
+.cta.primary:focus-visible {
+  transform: translateY(-2px);
+  box-shadow: 0 18px 32px rgba(0, 0, 0, 0.25);
+}
+
+.cta.secondary:hover,
+.cta.secondary:focus-visible {
+  transform: translateY(-2px);
+  background: rgba(255, 255, 255, 0.24);
+  box-shadow: 0 14px 26px rgba(0, 0, 0, 0.22);
+}
+
+button.cta {
+  font-family: inherit;
+}
+
+.hero-status {
+  font-size: 0.9rem;
+  color: var(--text-secondary);
+  min-height: 1.2rem;
+}
+
+.hero .hero-status {
+  color: rgba(255, 255, 255, 0.72);
+}
+
+/* Helps page */
+
+.helps-page {
+  background: linear-gradient(180deg, #f8f8fa 0%, #ffffff 60%);
+}
+
+.helps-main {
+  padding: clamp(48px, 10vw, 96px) clamp(20px, 6vw, 80px) 120px;
+}
+
+.helps-hero {
+  max-width: 720px;
+  margin: 0 auto;
+}
+
+.helps-card {
+  background-color: #fff;
+  border-radius: 32px;
+  padding: clamp(40px, 7vw, 64px);
+  box-shadow: 0 30px 70px rgba(15, 23, 42, 0.12);
+  text-align: center;
+}
+
+.helps-card .subhead {
+  max-width: 480px;
+  margin: 0 auto clamp(32px, 6vw, 48px);
+}
+
+.select-label {
+  display: block;
+  font-weight: 600;
+  margin-bottom: 12px;
+  color: var(--text-secondary);
+}
+
+.select-wrapper {
+  position: relative;
+}
+
+.book-select {
+  width: 100%;
+  padding: 16px 20px;
+  border-radius: 20px;
+  border: 1px solid rgba(0, 0, 0, 0.12);
+  font-size: 1rem;
+  font-family: inherit;
+  background-color: var(--surface);
+  appearance: none;
+}
+
+.book-select:focus {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
+.select-wrapper::after {
+  content: "⌄";
+  position: absolute;
+  right: 20px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 1.1rem;
+  pointer-events: none;
+  color: var(--text-secondary);
+}
+
+.helps-status {
+  margin-top: 24px;
+  min-height: 1.2rem;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}


### PR DESCRIPTION
## Summary
- remove the inline preview art from each landing hero so only the full-width photography shows
- rework the hero layout to keep copy and calls-to-action centered across breakpoints with neutral overlays

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_b_68d5e4cb7f348332a8485a431c7b3b3f