### PR TITLE
Use local hero background images

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,7 +5,6 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta name="description" content="Discover the translationCore desktop app and unfoldingWord training resources.">
   <title>translationCore — unfoldingWord Resources</title>
-  <link rel="preconnect" href="https://images.unsplash.com" crossorigin>
   <link rel="stylesheet" href="styles.css">
 </head>
 <body>
@@ -23,7 +22,7 @@
   </header>
 
   <main>
-    <section id="translationcore" class="hero hero-translationcore" style="--hero-image: url('https://images.unsplash.com/photo-1545239351-1141bd82e8a6?auto=format&fit=crop&w=2400&q=80');">
+    <section id="translationcore" class="hero hero-translationcore" style="--hero-image: url('images/translationcore-hero.png');">
       <div class="hero-content">
         <div class="hero-copy">
           <p class="eyebrow">translationCore software</p>
@@ -38,7 +37,7 @@
       </div>
     </section>
 
-    <section id="translation-helps" class="hero hero-helps" style="--hero-image: url('https://images.unsplash.com/photo-1524995997946-a1c2e315a42f?auto=format&fit=crop&w=2400&q=80');">
+    <section id="translation-helps" class="hero hero-helps" style="--hero-image: url('images/translation-helps-hero.png');">
       <div class="hero-content">
         <div class="hero-copy">
           <p class="eyebrow">unfoldingWord translation helps</p>
@@ -52,7 +51,7 @@
       </div>
     </section>
 
-    <section id="church-training" class="hero hero-training" style="--hero-image: url('https://images.unsplash.com/photo-1522202176988-66273c2fd55f?auto=format&fit=crop&w=2400&q=80');">
+    <section id="church-training" class="hero hero-training" style="--hero-image: url('images/church-training-hero.png');">
       <div class="hero-content">
         <div class="hero-copy">
           <p class="eyebrow">Church-Based Bible Translation Training</p>
@@ -66,7 +65,7 @@
       </div>
     </section>
 
-    <section id="foundations-bt" class="hero hero-foundations" style="--hero-image: url('https://images.unsplash.com/photo-1471286174890-9c112ffca5b4?auto=format&fit=crop&w=2400&q=80');">
+    <section id="foundations-bt" class="hero hero-foundations" style="--hero-image: url('images/foundations-hero.png');">
       <div class="hero-content">
         <div class="hero-copy">
           <p class="eyebrow">Foundations Bible Translation</p>


### PR DESCRIPTION
## Summary
- update the landing page hero sections to source their background images from the existing local assets
- remove the preconnect hint to the external image host since the images now load locally

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d6abd4a594833281ce8b7844dfeda4