### PR TITLE
Add translation helps modal to landing page

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,15 @@
           <h2>Insights and notes that illuminate every verse</h2>
           <p class="subhead">Download the latest translation notes, questions, and key terms so your team never loses momentum in Scripture checking.</p>
           <div class="hero-actions">
-            <a class="cta primary" href="helps.html">Download helps</a>
+            <button
+              id="download-helps"
+              class="cta primary"
+              type="button"
+              aria-haspopup="dialog"
+              aria-expanded="false"
+            >
+              Download helps
+            </button>
             <a class="cta secondary" href="https://preview.door43.org" target="_blank" rel="noopener">Choose your own</a>
           </div>
         </div>
@@ -79,6 +87,34 @@
     </section>
   </main>
 
+  <div
+    id="helps-dialog"
+    class="helps-dialog"
+    role="dialog"
+    aria-modal="true"
+    aria-labelledby="helps-dialog-title"
+    hidden
+    aria-hidden="true"
+  >
+    <div class="helps-dialog__backdrop" data-helps-close></div>
+    <div class="helps-dialog__panel helps-card">
+      <button type="button" class="helps-dialog__close" data-helps-close aria-label="Close download helps dialog">
+        ×
+      </button>
+      <p class="eyebrow">Translation Notes</p>
+      <h2 id="helps-dialog-title">Pick a book to open its PDF instantly</h2>
+      <p class="subhead">Choose a Bible book to jump straight into the latest unfoldingWord translation notes (v86.1).</p>
+      <label class="select-label" for="book-select">Book of the Bible</label>
+      <div class="select-wrapper">
+        <select id="book-select" class="book-select">
+          <option value="" disabled selected>Select a book…</option>
+        </select>
+      </div>
+      <p id="download-message" class="hero-status helps-status" aria-live="polite"></p>
+    </div>
+  </div>
+
   <script src="scripts/main.js" defer></script>
+  <script src="scripts/helps.js" defer></script>
 </body>
 </html>

--- a/scripts/main.js
+++ b/scripts/main.js
@@ -134,4 +134,82 @@ document.addEventListener('DOMContentLoaded', () => {
       }, 2500);
     }
   });
+
+  const helpsTrigger = document.getElementById('download-helps');
+  const helpsDialog = document.getElementById('helps-dialog');
+  const helpsCloseButtons = helpsDialog ? helpsDialog.querySelectorAll('[data-helps-close]') : [];
+  const helpsSelect = helpsDialog ? helpsDialog.querySelector('#book-select') : null;
+  const helpsMessage = helpsDialog ? helpsDialog.querySelector('#download-message') : null;
+  let lastFocusedElement = null;
+
+  const isDialogOpen = () => Boolean(helpsDialog && !helpsDialog.hasAttribute('hidden'));
+
+  const closeHelpsDialog = () => {
+    if (!helpsDialog) return;
+    helpsDialog.classList.remove('is-open');
+    helpsDialog.setAttribute('aria-hidden', 'true');
+    document.body.classList.remove('dialog-open');
+    setTimeout(() => {
+      if (helpsDialog.getAttribute('aria-hidden') === 'true') {
+        helpsDialog.setAttribute('hidden', '');
+      }
+    }, 180);
+
+    if (helpsTrigger) {
+      helpsTrigger.setAttribute('aria-expanded', 'false');
+    }
+
+    if (lastFocusedElement && typeof lastFocusedElement.focus === 'function') {
+      lastFocusedElement.focus();
+    }
+  };
+
+  const openHelpsDialog = () => {
+    if (!helpsDialog) return;
+    lastFocusedElement = document.activeElement;
+    helpsDialog.removeAttribute('hidden');
+    helpsDialog.setAttribute('aria-hidden', 'false');
+    document.body.classList.add('dialog-open');
+    requestAnimationFrame(() => {
+      helpsDialog.classList.add('is-open');
+    });
+
+    if (helpsTrigger) {
+      helpsTrigger.setAttribute('aria-expanded', 'true');
+    }
+
+    if (helpsSelect) {
+      helpsSelect.selectedIndex = 0;
+      helpsSelect.focus();
+    }
+
+    if (helpsMessage) {
+      helpsMessage.textContent = '';
+    }
+  };
+
+  if (helpsTrigger && helpsDialog) {
+    helpsTrigger.addEventListener('click', (event) => {
+      event.preventDefault();
+      openHelpsDialog();
+    });
+
+    helpsCloseButtons.forEach((button) => {
+      button.addEventListener('click', () => {
+        closeHelpsDialog();
+      });
+    });
+
+    helpsDialog.addEventListener('click', (event) => {
+      if (event.target && event.target.hasAttribute('data-helps-close')) {
+        closeHelpsDialog();
+      }
+    });
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && isDialogOpen()) {
+        closeHelpsDialog();
+      }
+    });
+  }
 });

--- a/styles.css
+++ b/styles.css
@@ -270,6 +270,78 @@ button.cta {
   color: rgba(255, 255, 255, 0.72);
 }
 
+body.dialog-open {
+  overflow: hidden;
+}
+
+.helps-dialog {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(24px, 6vw, 48px);
+  background: rgba(15, 23, 42, 0.55);
+  z-index: 30;
+  opacity: 0;
+  transition: opacity 200ms ease;
+}
+
+.helps-dialog.is-open {
+  opacity: 1;
+}
+
+.helps-dialog[hidden] {
+  display: none;
+}
+
+.helps-dialog__backdrop {
+  position: absolute;
+  inset: 0;
+  cursor: pointer;
+}
+
+.helps-dialog__panel {
+  position: relative;
+  width: min(100%, 640px);
+  max-height: min(92vh, 680px);
+  overflow-y: auto;
+  padding-block: clamp(32px, 7vw, 56px);
+  padding-inline: clamp(28px, 7vw, 56px);
+  z-index: 1;
+}
+
+.helps-dialog__close {
+  position: absolute;
+  top: clamp(16px, 4vw, 24px);
+  right: clamp(16px, 4vw, 24px);
+  border: none;
+  background: rgba(15, 23, 42, 0.08);
+  color: var(--text-secondary);
+  font-size: 1.5rem;
+  line-height: 1;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  cursor: pointer;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  transition: background-color 180ms ease, color 180ms ease, transform 180ms ease;
+}
+
+.helps-dialog__close:hover,
+.helps-dialog__close:focus-visible {
+  background: rgba(15, 23, 42, 0.14);
+  color: var(--text-primary);
+  transform: scale(1.05);
+}
+
+.helps-dialog__close:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+
 /* Helps page */
 
 .helps-page {


### PR DESCRIPTION
## Summary
- replace the Helps CTA with an on-page dialog trigger and embed the book picker markup in the landing page
- add styling and focus management so the new dialog behaves like a modal overlay
- load the existing helps picker script on the landing page to populate the book list and start downloads

## Testing
- python -m http.server 8000


------
https://chatgpt.com/codex/tasks/task_b_68d6b1d301e48332a50544192e510526